### PR TITLE
feature: support usage with browserify

### DIFF
--- a/Markdown.Editor.js
+++ b/Markdown.Editor.js
@@ -1,6 +1,15 @@
-﻿// needs Markdown.Converter.js at the moment
-
 (function () {
+
+    var output, Converter, HookCollection;
+    if (typeof exports === "object" && typeof require === "function") { // we're in a CommonJS (e.g. Node.js) module
+        output = exports;
+        Converter = require("./Markdown.Converter").Converter;
+        HookCollection = require("./Markdown.Converter").HookCollection;
+    } else {
+        output = window.Markdown;
+        Converter = output.Converter;
+        HookCollection = output.HookCollection;
+    }
 
     var util = {},
         position = {},
@@ -94,8 +103,8 @@
     // - getConverter() returns the markdown converter object that was passed to the constructor
     // - run() actually starts the editor; should be called after all necessary plugins are registered. Calling this more than once is a no-op.
     // - refreshPreview() forces the preview to be updated. This method is only available after run() was called.
-    Markdown.Editor = function (markdownConverter, idPostfix, options) {
-        
+    output.Editor = function (markdownConverter, idPostfix, options) {
+
         options = options || {};
 
         if (typeof options.handler === "function") { //backwards compatible behavior
@@ -106,19 +115,19 @@
             options.strings.help = options.strings.help || options.helpButton.title;
         }
         var getString = function (identifier) { return options.strings[identifier] || defaultsStrings[identifier]; }
-        
+
         idPostfix = idPostfix || "";
 
         this.getPostfix = function () { return idPostfix; }
 
-        var hooks = this.hooks = new Markdown.HookCollection();
+        var hooks = this.hooks = new HookCollection();
         hooks.addNoop("onPreviewRefresh");       // called with no arguments after the preview has been refreshed
         hooks.addNoop("postBlockquoteCreation"); // called with the user's selection *after* the blockquote was created; should return the actual to-be-inserted text
         hooks.addFalse("insertImageDialog");     /* called with one parameter: a callback to be called with the URL of the image. If the application creates
                                                   * its own image insertion dialog, this hook should return true, and the callback should be called with the chosen
                                                   * image url (or null if the user cancelled). If this hook returns false, the default dialog will be used.
                                                   */
-        hooks.addNoop("imageConvertedToLink");  // called with no arguments if an image was converted 
+        hooks.addNoop("imageConvertedToLink");  // called with no arguments if an image was converted
         hooks.addFalse("insertLinkDialog");     /* called with one parameter: a callback to be called with the URL.
                                                  * works identical to insertImageDialog (see above)
                                                  */
@@ -1034,9 +1043,9 @@
 
         var background = doc.createElement("div"),
             style = background.style;
-        
+
         background.className = "wmd-prompt-background";
-        
+
         style.position = "absolute";
         style.top = "0";
 
@@ -1653,7 +1662,7 @@
 
         var defs = "";
         var regex = /\[(\d+)\]/g;
-        
+
         // The above regex, used to update [foo][13] references after renumbering,
         // is much too liberal; it can catch things that are not actually parsed
         // as references (notably: code). It's impossible to know which matches are
@@ -1667,7 +1676,7 @@
         var complete = chunk.before + chunk.selection + chunk.after;
         var rendered = this.converter.makeHtml(complete);
         var testlink = "http://this-is-a-real-link.biz/";
-        
+
         // If our fake link appears in the rendered version *before* we have added it,
         // this probably means you're a Meta Stack Exchange user who is deliberately
         // trying to break this feature. You can still break this workaround if you
@@ -1675,20 +1684,20 @@
         // that case, consider yourself unsupported.
         while (rendered.indexOf(testlink) != -1)
             testlink += "nicetry/";
-        
+
         var fakedefs = "\n\n";
 
         var uniquified = complete.replace(regex, function uniquify(wholeMatch, id, offset) {
             fakedefs += " [" + offset + "]: " + testlink + offset + "/unicorn\n";
             return "[" + offset + "]";
         });
-        
+
         rendered = this.converter.makeHtml(uniquified + fakedefs);
-        
+
         var okayToModify = function(offset) {
             return rendered.indexOf(testlink + offset + "/unicorn") !== -1;
         }
-        
+
         // property names are "L_" + link (prefixed to prevent collisions with built-in properties),
         // values are the definition numbers
         var addedDefsByUrl = {};
@@ -1730,7 +1739,7 @@
         var len = chunk.before.length;
         chunk.before = chunk.before.replace(regex, getLink);
         skippedChars += len;
-        
+
         len = chunk.selection.length;
         var refOut;
         if (linkDef) {
@@ -1739,7 +1748,7 @@
         else {
             chunk.selection = chunk.selection.replace(regex, getLink);
         }
-        skippedChars += len;        
+        skippedChars += len;
 
         chunk.after = chunk.after.replace(regex, getLink);
 
@@ -1759,7 +1768,7 @@
     // sure the URL and the optinal title are "nice".
     function properlyEncoded(linkdef) {
         return linkdef.replace(/^\s*(.*?)(?:\s+"(.+)")?\s*$/, function (wholematch, link, title) {
-            
+
             var inQueryString = false;
 
             // Having `[^\w\d-./]` in there is just a shortcut that lets us skip
@@ -1784,7 +1793,7 @@
                         inQueryString = true;
                         return "?";
                         break;
-                    
+
                     // In the query string, a plus and a space are identical -- normalize.
                     // Not strictly necessary, but identical behavior to the previous version
                     // of this function.
@@ -1795,7 +1804,7 @@
                 }
                 return encodeURI(match);
             })
-            
+
             if (title) {
                 title = title.trim ? title.trim() : title.replace(/^\s*/, "").replace(/\s*$/, "");
                 title = title.replace(/"/g, "quot;").replace(/\(/g, "&#40;").replace(/\)/g, "&#41;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
@@ -1820,7 +1829,7 @@
 
         }
         else {
-            
+
             // We're moving start and end tag back into the selection, since (as we're in the else block) we're not
             // *removing* a link, but *adding* one, so whatever findTags() found is now back to being part of the
             // link text. linkEnteredCallback takes care of escaping any brackets.
@@ -1858,7 +1867,7 @@
                     // would mean a zero-width match at the start. Since zero-width matches advance the string position,
                     // the first bracket could then not act as the "not a backslash" for the second.
                     chunk.selection = (" " + chunk.selection).replace(/([^\\](?:\\\\)*)(?=[[\]])/g, "$1\\").substr(1);
-                    
+
                     var linkDef = " [999]: " + properlyEncoded(link);
 
                     var num = that.addLinkDef(chunk, linkDef);
@@ -1917,7 +1926,7 @@
         chunk.before = chunk.before.replace(/(\n|^)[ ]{0,3}([*+-]|\d+[.])[ \t]*\n$/, "\n\n");
         chunk.before = chunk.before.replace(/(\n|^)[ ]{0,3}>[ \t]*\n$/, "\n\n");
         chunk.before = chunk.before.replace(/(\n|^)[ \t]+\n$/, "\n\n");
-        
+
         // There's no selection, end the cursor wasn't at the end of the line:
         // The user wants to split the current list item / code line / blockquote line
         // (for the latter it doesn't really matter) in two. Temporarily select the
@@ -1945,7 +1954,7 @@
                 commandMgr.doCode(chunk);
             }
         }
-        
+
         if (fakeSelection) {
             chunk.after = chunk.selection + chunk.after;
             chunk.selection = "";

--- a/Markdown.Sanitizer.js
+++ b/Markdown.Sanitizer.js
@@ -7,7 +7,7 @@
         output = window.Markdown;
         Converter = output.Converter;
     }
-        
+
     output.getSanitizingConverter = function () {
         var converter = new Converter();
         converter.hooks.chain("postConversion", sanitizeHtml);
@@ -41,7 +41,7 @@
                         return "%27";
                     else
                         return encodeURIComponent(c);
-                    
+
                 });
             });
             if (anyChange && (encoded.match(a_white) || encoded.match(img_white)))
@@ -53,9 +53,9 @@
     /// <summary>
     /// attempt to balance HTML tags in the html string
     /// by removing any unmatched opening or closing tags
-    /// IMPORTANT: we *assume* HTML has *already* been 
+    /// IMPORTANT: we *assume* HTML has *already* been
     /// sanitized and is safe/sane before balancing!
-    /// 
+    ///
     /// adapted from CODESNIPPET: A8591DBA-D1D3-11DE-947C-BA5556D89593
     /// </summary>
     function balanceTags(html) {

--- a/node-pagedown.js
+++ b/node-pagedown.js
@@ -1,2 +1,6 @@
 exports.Converter = require("./Markdown.Converter").Converter;
 exports.getSanitizingConverter = require("./Markdown.Sanitizer").getSanitizingConverter;
+
+if(process.browser) {
+	exports.Editor = require('./Markdown.Editor').Editor;
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "repository": { "type": "hg", "url": "https://code.google.com/p/pagedown/" },
     "keywords": ["markdown"],
     "license": "MIT",
-    "files": ["Markdown.Converter.js", "Markdown.Sanitizer.js", "node-pagedown.js"],
+    "files": ["Markdown.Converter.js", "Markdown.Sanitizer.js", "Markdown.Editor.js", "wmd-buttons.png", "node-pagedown.js"],
     "main": "node-pagedown.js",
     "bugs": "http://code.google.com/p/pagedown/issues/list",
     "homepage": "http://code.google.com/p/pagedown/wiki/PageDown"


### PR DESCRIPTION
I've made some changes needed to be able to use the editor in browser with browserify. I've added CommonJS module support to Editor, and include it in package exports, if process looks like a browser build.

In this version editor is available to web applications built with CJS modules, and rest of the package can be still loaded into node.js.